### PR TITLE
Feature/check services

### DIFF
--- a/check-services/README.md
+++ b/check-services/README.md
@@ -1,0 +1,87 @@
+# Service Health Check Script
+
+## Overview
+
+This Go script checks the health of multiple personal services by sending HTTP requests to specified endpoints and verifying the expected responses.  
+It's designed to run automatically (e.g., at startup via systemd) and logs results to a file, while sending a desktop notification summarizing service statuses.
+
+## Features
+
+- Checks each service using a user-provided configuration file.
+- Logs detailed results and status summaries to `~/.local/share/service-check.log`.
+- Sends a desktop notification summarizing which services are up or down.
+- Command-line interface for explicit configuration file selection.
+
+## Usage
+
+### 1. Build the Script
+
+In the `check-services` directory, run:
+
+```sh
+go build -o check_services
+```
+Or install system-wide (if desired):
+
+```sh
+go install
+```
+
+### 2. Prepare Your Configuration File
+
+Create a JSON file describing each service to check.  
+Example `services.json`:
+
+```json
+[
+    {
+        "name": "Personal Website",
+        "url": "https://eliasld.com",
+        "expected": "<!DOCTYPE html>"
+    },
+    {
+        "name": "Backend Health",
+        "url": "http://<public_ip_address>:8080/health",
+        "expected": "Server is healthy !"
+    }
+]
+```
+
+**Each object must have:**
+- `name`: a unique, human-readable identifier for the service.
+- `url`: the endpoint to query (e.g., home page for a website, `/health` for an API).
+- `expected`: a string that should be present in the response to consider the service healthy.
+
+### 3. Run the Script
+
+You must provide the path to your configuration file as the first argument:
+
+```sh
+./check_services /path/to/services.json
+```
+
+### 4. Log File
+
+All service check results and status summaries are logged to:
+
+```
+~/.local/share/service-check.log
+```
+
+### 5. Desktop Notifications
+
+A desktop notification (using `notify-send`) will show a summary after each run.  
+Make sure you have a notification daemon running (e.g., `dunst`).
+
+### 6. Automate with systemd (optional)
+
+You can use a systemd user service and timer to run this script automatically at boot or intervals.  
+See the main project documentation for an example.
+
+## Disclaimer
+
+- The script will fail if the configuration file is missing or invalid.
+- Requires network connectivity to reach each service endpoint.
+- The script checks for the presence of the expected string in the HTTP response; for more advanced checks, modify the script accordingly.
+
+---

--- a/check-services/check-services.go
+++ b/check-services/check-services.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -86,4 +87,23 @@ func main() {
 			log(fmt.Sprintf("[FAIL] %s (%s): Response does not match expected.", site.Name, site.URL))
 		}
 	}
+
+	// Build notification summary
+	var summary strings.Builder
+	if len(okList) > 0 {
+		summary.WriteString("Working: " + strings.Join(okList, ", ") + "\n")
+	} else {
+		summary.WriteString("Working: None\n")
+	}
+	if len(failList) > 0 {
+		summary.WriteString("Failing: " + strings.Join(failList, ", "))
+	} else {
+		summary.WriteString("Failing: None 🎉")
+	}
+
+	// Log the summary
+	log("Summary: " + strings.ReplaceAll(summary.String(), "\n", " | "))
+
+	// Send desktop notification of the summary
+	exec.Command("notify-send", "Service Status", summary.String()).Run()
 }

--- a/check-services/check-services.go
+++ b/check-services/check-services.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Site struct {
+	Name     string `json:"name"`
+	URL      string `json:"url"`
+	Expected string `json:"expected"`
+}

--- a/check-services/check-services.go
+++ b/check-services/check-services.go
@@ -18,7 +18,14 @@ type Site struct {
 }
 
 func main() {
-	configFile := "services.json"
+	var configFile string
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: check-services <config.json>")
+		fmt.Println("	<config.json>: Path to your JSON configuration file.")
+		os.Exit(1)
+	}
+	configFile = os.Args[1]
+
 	logDir := filepath.Join(os.Getenv("HOME"), ".local", "share")
 	logFile := filepath.Join(logDir, "check-services.log")
 

--- a/check-services/check-services.go
+++ b/check-services/check-services.go
@@ -3,14 +3,80 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 type Site struct {
 	Name     string `json:"name"`
 	URL      string `json:"url"`
 	Expected string `json:"expected"`
+}
+
+func main() {
+	configFile := "services.json"
+	logDir := filepath.Join(os.Getenv("HOME"), ".local", "share")
+	logFile := filepath.Join(logDir, "check-services.log")
+
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not create log directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not open log file: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	// Helper for logging with timestamp
+	log := func(line string) {
+		ts := time.Now().Format("[2006-01-02 15:04:05]")
+		fmt.Fprintf(f, "%s %s\n", ts, line)
+	}
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		log(fmt.Sprintf("Error reading config file: %v", err))
+		return
+	}
+
+	var sites []Site
+	err = json.Unmarshal(data, &sites)
+	if err != nil {
+		log(fmt.Sprintf("Error parsing JSON: %v", err))
+		return
+	}
+
+	var okList, failList []string
+
+	for _, site := range sites {
+		resp, err := http.Get(site.URL)
+		if err != nil {
+			failList = append(failList, site.Name)
+			log(fmt.Sprintf("[FAIL] %s (%s): HTTP error: %v", site.Name, site.URL, err))
+			continue
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			failList = append(failList, site.Name)
+			log(fmt.Sprintf("[FAIL] %s (%s) Error reading response: %v", site.Name, site.URL, err))
+			continue
+		}
+
+		content := string(body)
+		if strings.Contains(content, site.Expected) {
+			okList = append(okList, site.Name)
+			log(fmt.Sprintf("[OK] %s (%s): Response matches expected.", site.Name, site.URL))
+		} else {
+			failList = append(failList, site.Name)
+			log(fmt.Sprintf("[FAIL] %s (%s): Response does not match expected.", site.Name, site.URL))
+		}
+	}
 }

--- a/check-services/go.mod
+++ b/check-services/go.mod
@@ -1,0 +1,3 @@
+module github.com/EliasLd/check-services
+
+go 1.25.1


### PR DESCRIPTION
# Service Health Check Script

## Overview

This pull request introduces a Go-based service health check tool that verifies the status of multiple personal services via HTTP requests. Each service is described in a JSON configuration file with three fields: `name`, `url`, and `expected`. The script checks each endpoint, compares the response to the expected content, logs detailed results to a file, and sends a desktop notification summarizing which services are working or failing.

## Commit History

- **Add base go script for checking running services:** Initial commit with the foundational service checking logic.
- **Add json file reading + core service checking and response logging:** Implements reading a JSON config and checking each service’s health, with result logging.
- **Add mandatory json config file path:** Requires the path to the JSON config as a mandatory script argument for flexibility and portability.
- **Add summary logging + desktop notification:** Logs a status summary and sends a notification with working/failing services to the desktop.

## Features

- Reads a user-specified JSON config file describing each service to check.
- Performs HTTP requests and compares responses to expected values.
- Logs all checks, errors, and summaries to `~/.local/share/service-check.log`.
- Sends a desktop notification with a recap after each run.
- Designed to be run as a systemd user service/timer for automated health checks, e.g., 2 minutes after boot.

## Usage

- Build the script with `go build -o check_services`.
- Prepare your `services.json` config file with the following structure:
  ```json
  [
      {
          "name": "Personal Website",
          "url": "https://eliasld.com",
          "expected": "<!DOCTYPE html>"
      },
      {
          "name": "Backend Health",
          "url": "http://<public_ip_address>:8080/health",
          "expected": "Server is healthy !"
      }
  ]
  ```
- Run the script with the config file as an argument:
  ```sh
  ./check_services /path/to/services.json
  ```
- View logs at `~/.local/share/service-check.log`.

## Automation

A systemd user service and timer can be used to automate the script, running it a set time after boot or at regular intervals.

---